### PR TITLE
Update snippet to include `insert_final_newline`

### DIFF
--- a/snippets/ini.json
+++ b/snippets/ini.json
@@ -18,6 +18,7 @@
       "end_of_line = ${endOfLine:lf}",
       "charset = utf-8",
       "trim_trailing_whitespace = true",
+      "insert_final_newline = true",
       "\n[*.{js,css,scss}]",
       "indent_size = 2",
       "\n[*.html]",


### PR DESCRIPTION
It's common practice to insert a newline at the end of a file.
